### PR TITLE
query builder generation only from connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ludb",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ludb",
-            "version": "0.0.8",
+            "version": "0.0.9",
             "license": "MIT",
             "dependencies": {
                 "@types/get-value": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ludb",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "description": "Nodejs Query Builder",
     "author": "Claudio Pennati <claudio.pennati@gmail.com>",
     "license": "MIT",

--- a/src/__tests__/code/connections/connection-session.test.ts
+++ b/src/__tests__/code/connections/connection-session.test.ts
@@ -8,7 +8,6 @@ import TransactionCommitted from '../../../events/transaction-committed';
 import TransactionCommitting from '../../../events/transaction-committing';
 import TransactionRolledBack from '../../../events/transaction-rolledback';
 import Grammar from '../../../query/grammars/grammar';
-import QueryBuilder from '../../../query/query-builder';
 
 import Expression from '../../../query/expression';
 import {
@@ -16,7 +15,6 @@ import {
     MockedConnectionSession,
     MockedConnectionSessionWithResults,
     MockedConnectionSessionWithResultsSets,
-    getBuilder,
     getConnection
 } from '../fixtures/mocked';
 import { MockedConnection } from '../fixtures/mocked-connections';
@@ -283,23 +281,6 @@ describe('Connection Session', () => {
         const session = new MockedConnectionSession(connection);
         session.prepareBindings([null, 'Claudio']);
         expect(spiedConnection).toHaveBeenCalledWith([null, 'Claudio']);
-    });
-
-    it('Works Table', () => {
-        const connection = getConnection();
-        const session = new MockedConnectionSession(connection);
-        const builder = getBuilder();
-        const spiedBuilder = jest.spyOn(builder, 'from');
-        const spiedQuery = jest.spyOn(session, 'query').mockReturnValueOnce(builder);
-        expect(session.table('test', 'name')).toBe(builder);
-        expect(spiedQuery).toHaveBeenCalled();
-        expect(spiedBuilder).toHaveBeenCalledWith('test', 'name');
-    });
-
-    it('Works Query', () => {
-        const connection = getConnection();
-        const session = new MockedConnectionSession(connection);
-        expect(session.query()).toBeInstanceOf(QueryBuilder);
     });
 
     it('Works Select Use Read Pdo', async () => {

--- a/src/__tests__/code/connections/connection.test.ts
+++ b/src/__tests__/code/connections/connection.test.ts
@@ -20,6 +20,7 @@ import SqliteBuilder from '../../../schema/builders/sqlite-builder';
 import SqlserverBuilder from '../../../schema/builders/sqlserver-builder';
 import SchemaGrammar from '../../../schema/grammars/grammar';
 import {
+    getBuilder,
     getConnection,
     getMysqlConnection,
     getPostgresConnection,
@@ -334,16 +335,19 @@ describe('Connection', () => {
         const connection = getConnection();
         const session = new ConnectionSession(connection);
         jest.spyOn(connection, 'session').mockReturnValue(session);
-        const spiedSession = jest.spyOn(session, 'table');
-        expect(connection.table('test', 'name')).toBeInstanceOf(QueryBuilder);
-        expect(spiedSession).toHaveBeenCalledWith('test', 'name');
+        const builder = getBuilder();
+        const spiedBuilder = jest.spyOn(builder, 'from');
+        const spiedQuery = jest.spyOn(connection, 'query').mockReturnValueOnce(builder);
+
+        expect(connection.table('test', 'name')).toBe(builder);
+        expect(spiedQuery).toHaveBeenCalled();
+        expect(spiedBuilder).toHaveBeenCalledWith('test', 'name');
     });
 
     it('Works Query', () => {
         const connection = getConnection();
         const session = new ConnectionSession(connection);
-        jest.spyOn(connection, 'session').mockReturnValue(session);
-        const spiedSession = jest.spyOn(session, 'query');
+        const spiedSession = jest.spyOn(connection, 'session').mockReturnValue(session);
         expect(connection.query()).toBeInstanceOf(QueryBuilder);
         expect(spiedSession).toHaveBeenCalledTimes(1);
     });

--- a/src/connections/connection-session.ts
+++ b/src/connections/connection-session.ts
@@ -19,14 +19,11 @@ import TransactionCommitted from '../events/transaction-committed';
 import TransactionCommitting from '../events/transaction-committing';
 import TransactionRolledBack from '../events/transaction-rolledback';
 import ExpressionContract from '../query/expression-contract';
-import QueryBuilder from '../query/query-builder';
 import BindToI from '../types/bind-to';
 import { CacheSessionOptions } from '../types/cache';
 import ConnectionConfig from '../types/config';
 import DriverConnectionI, { BeforeExecutingCallback, ConnectionSessionI, LoggedQuery } from '../types/connection';
-import { Binding, BindingExclude, BindingExcludeObject, BindingObject, Stringable } from '../types/generics';
-import { QueryAbleCallback } from '../types/query/grammar-builder';
-import QueryBuilderI from '../types/query/query-builder';
+import { Binding, BindingExclude, BindingExcludeObject, BindingObject } from '../types/generics';
 import { causedByConcurrencyError, causedByLostConnection } from '../utils';
 
 export type RunCallback<T> = (query: string, bindings: Binding[] | BindingObject) => Promise<T>;
@@ -122,20 +119,6 @@ class ConnectionSession<DriverConnection extends DriverConnectionI = DriverConne
      */
     public getReference(): string {
         return this.referenceId;
-    }
-
-    /**
-     * Begin a fluent query against a database table.
-     */
-    public table(table: QueryAbleCallback<QueryBuilderI> | QueryBuilderI | Stringable, as?: string): QueryBuilderI {
-        return this.query().from(table, as);
-    }
-
-    /**
-     * Get a new query builder instance.
-     */
-    public query(): QueryBuilderI {
-        return new QueryBuilder(this);
     }
 
     /**

--- a/src/connections/connection.ts
+++ b/src/connections/connection.ts
@@ -6,11 +6,12 @@ import EventEmitter from 'node:events';
 import { bindTo } from '../bindings';
 import CacheManager from '../cache-manager';
 import QueryExecuted from '../events/query-executed';
+import { QueryBuilder } from '../query';
 import ExpressionContract from '../query/expression-contract';
 import Grammar from '../query/grammars/grammar';
 import SchemaGrammar from '../schema/grammars/grammar';
-import { CacheSessionOptions } from '../types';
 import BindToI from '../types/bind-to';
+import { CacheSessionOptions } from '../types/cache';
 import ConnectionConfig, { FlattedConnectionConfig, ReadAndWriteConnectionOptions } from '../types/config';
 import DriverConnectionI, { BeforeExecutingCallback, ConnectionSessionI, LoggedQuery } from '../types/connection';
 import ConnectorI from '../types/connector';
@@ -440,14 +441,14 @@ abstract class Connection<const Config extends ConnectionConfig = ConnectionConf
      * Begin a fluent query against a database table.
      */
     public table(table: QueryAbleCallback<QueryBuilderI> | QueryBuilderI | Stringable, as?: string): QueryBuilderI {
-        return this.session().table(table, as);
+        return this.query().from(table, as);
     }
 
     /**
      * Get a new query builder instance.
      */
     public query(): QueryBuilderI {
-        return this.session().query();
+        return new QueryBuilder(this.session());
     }
 
     /**

--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -3,7 +3,7 @@ import Cursor from '../paginations/cursor';
 import CursorPaginator from '../paginations/cursor-paginator';
 import LengthAwarePaginator from '../paginations/length-aware-paginator';
 import Paginator from '../paginations/paginator';
-import { CacheSessionOptions } from '../types';
+import { CacheSessionOptions } from '../types/cache';
 import { Binding, Stringable } from '../types/generics';
 import PaginatorI, {
     CursorPaginatorI,
@@ -1045,7 +1045,7 @@ class QueryBuilder extends CommonGrammarBuilder implements QueryBuilderI {
      */
     public async insertUsing(
         columns: Stringable[],
-        query: QueryAbleCallback<QueryBuilderI> | QueryBuilderI | Stringable
+        query: QueryAbleCallback<GrammarBuilderI> | GrammarBuilderI | Stringable
     ): Promise<number> {
         this.applyBeforeQueryCallbacks();
 

--- a/src/schema/builders/builder.ts
+++ b/src/schema/builders/builder.ts
@@ -4,7 +4,7 @@ import { GrammarBuilder } from '../../query';
 import DriverConnectionI, { ConnectionSessionI } from '../../types/connection';
 import { Stringable } from '../../types/generics';
 import BlueprintI from '../../types/schema/blueprint';
-import QueryBuilderI, {
+import SchemaBuilderI, {
     BlueprintCallback,
     BlueprintResolver,
     MorphKeyType,
@@ -23,7 +23,7 @@ import Blueprint from '../blueprint';
 import CommandViewDefinition from '../definitions/commands/command-view-definition';
 
 class QueryBuilder<Session extends ConnectionSessionI<DriverConnectionI> = ConnectionSessionI<DriverConnectionI>>
-    implements QueryBuilderI<Session>
+    implements SchemaBuilderI<Session>
 {
     /**
      * The schema grammar instance.

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -28,16 +28,6 @@ export interface LoggedQuery {
 
 interface BaseConnection {
     /**
-     * Begin a fluent query against a database table.
-     */
-    table(table: QueryAbleCallback<QueryBuilderI> | QueryBuilderI | Stringable, as?: string): QueryBuilderI;
-
-    /**
-     * Get a new query builder instance.
-     */
-    query(): QueryBuilderI;
-
-    /**
      * Run a select statement and return a single result.
      */
     selectOne<T = Dictionary>(
@@ -207,6 +197,16 @@ interface BaseConnection {
 }
 
 export default interface DriverConnectionI extends BaseConnection {
+    /**
+     * Begin a fluent query against a database table.
+     */
+    table(table: QueryAbleCallback<QueryBuilderI> | QueryBuilderI | Stringable, as?: string): QueryBuilderI;
+
+    /**
+     * Get a new query builder instance.
+     */
+    query(): QueryBuilderI;
+
     /**
      * Define Cache Strategy for current session
      */

--- a/src/types/query/query-builder.ts
+++ b/src/types/query/query-builder.ts
@@ -263,7 +263,7 @@ export default interface QueryBuilderI extends GrammarBuilderI {
      */
     insertUsing(
         columns: Stringable[],
-        query: QueryAbleCallback<QueryBuilderI> | QueryBuilderI | Stringable
+        query: QueryAbleCallback<GrammarBuilderI> | GrammarBuilderI | Stringable
     ): Promise<number>;
 
     /**


### PR DESCRIPTION
query builder generation only from connection and not session
fix SchemaBuilder typo
fix insertUsing parameters types